### PR TITLE
Removidas declarações SUP 'top' da definição da classe brPerson.

### DIFF
--- a/schema/breduperson.0.0.6.schema
+++ b/schema/breduperson.0.0.6.schema
@@ -237,7 +237,6 @@ attributetype ( 1.3.6.1.4.1.15996.100.1.1.4.9
 objectclass ( 1.3.6.1.4.1.15996.100.1.2.1
     NAME 'brPerson'
     DESC 'Atributos sobre pessoas nascidas ou residentes no Brasil, nao se restringe somente ao ambito educacional'
-    SUP 'top'
     AUXILIARY
     MAY ( brcpf $ brpassport ) )
 
@@ -245,7 +244,6 @@ objectclass ( 1.3.6.1.4.1.15996.100.1.2.1
 objectclass ( 1.3.6.1.4.1.15996.100.1.2.2
     NAME 'brEduPerson'
     DESC 'Atributos referentes a uma pessoa com insercao em instituicao brasileira de ensino ou pesquisa'
-    SUP 'top'
     STRUCTURAL
     MUST ( braff $ brafftype)
     MAY ( brentr $ brexit ) )
@@ -254,7 +252,6 @@ objectclass ( 1.3.6.1.4.1.15996.100.1.2.2
 objectclass ( 1.3.6.1.4.1.15996.100.1.2.3
     NAME 'brBiometricData'
     DESC 'Atributos sobre dados biometricos das pessoas'
-    SUP 'top'
     STRUCTURAL
     MUST ( brbiosrc $  brbiodata )
     MAY (  brcapt ) )
@@ -263,9 +260,6 @@ objectclass ( 1.3.6.1.4.1.15996.100.1.2.3
 objectclass ( 1.3.6.1.4.1.15996.100.1.2.4
     NAME 'brEduVoIP'
     DESC 'Atributos com dados relativos a um telefone IP'
-    SUP 'top'
     STRUCTURAL
     MUST ( brvoipphone $ brvoipalias $  brvoiptype $  brvoipadmin )
     MAY (  brvoipfwr $  brvoipaddr $  brvoipexpiry $  brvoipbalance $  brvoipcredit ) )
-
-

--- a/schema/breduperson.0.0.6.schema
+++ b/schema/breduperson.0.0.6.schema
@@ -237,6 +237,7 @@ attributetype ( 1.3.6.1.4.1.15996.100.1.1.4.9
 objectclass ( 1.3.6.1.4.1.15996.100.1.2.1
     NAME 'brPerson'
     DESC 'Atributos sobre pessoas nascidas ou residentes no Brasil, nao se restringe somente ao ambito educacional'
+	SUP top
     AUXILIARY
     MAY ( brcpf $ brpassport ) )
 
@@ -244,6 +245,7 @@ objectclass ( 1.3.6.1.4.1.15996.100.1.2.1
 objectclass ( 1.3.6.1.4.1.15996.100.1.2.2
     NAME 'brEduPerson'
     DESC 'Atributos referentes a uma pessoa com insercao em instituicao brasileira de ensino ou pesquisa'
+	SUP top
     STRUCTURAL
     MUST ( braff $ brafftype)
     MAY ( brentr $ brexit ) )
@@ -252,6 +254,7 @@ objectclass ( 1.3.6.1.4.1.15996.100.1.2.2
 objectclass ( 1.3.6.1.4.1.15996.100.1.2.3
     NAME 'brBiometricData'
     DESC 'Atributos sobre dados biometricos das pessoas'
+	SUP top
     STRUCTURAL
     MUST ( brbiosrc $  brbiodata )
     MAY (  brcapt ) )
@@ -260,6 +263,7 @@ objectclass ( 1.3.6.1.4.1.15996.100.1.2.3
 objectclass ( 1.3.6.1.4.1.15996.100.1.2.4
     NAME 'brEduVoIP'
     DESC 'Atributos com dados relativos a um telefone IP'
+	SUP top
     STRUCTURAL
     MUST ( brvoipphone $ brvoipalias $  brvoiptype $  brvoipadmin )
     MAY (  brvoipfwr $  brvoipaddr $  brvoipexpiry $  brvoipbalance $  brvoipcredit ) )


### PR DESCRIPTION
Foram removidas as aspas simples de _SUP 'top'_ por se tratar de erro sintático, de acordo com as especificações de esquema LDAP.

Devido a este problema, ao tentar importar este esquema para o Apache Directory Server resulta em erro sintático.